### PR TITLE
Update noisecapt.sh

### DIFF
--- a/rootfs/usr/share/noisecapt/noisecapt.sh
+++ b/rootfs/usr/share/noisecapt/noisecapt.sh
@@ -100,12 +100,12 @@ while true; do
     # All dB levels are dBFS, or dB where the loudest (="full scale") is 0 dB
 
     if chk_enabled "$RECORD_MP3"; then
-        RMSREC="$(arecord -D hw:"$CARD,$DEVICE" -d "$CAPTURETIME" --fatal-errors --buffer-size=192000 -f dat -t raw -c 1 --quiet 2>/dev/null \
-                  | tee >(lame --quiet -r --preset phone -s 48 - "${OUTFILE}recording-$(date -d @"$AUDIOTIME" +%y%m%d-%H%M%S).mp3" >/dev/null 2>&1) \
+        RMSREC="$(arecord -D hw:"$CARD,$DEVICE" -d "$CAPTURETIME" --fatal-errors --buffer-size=192000 -f dat -t raw -c 1 -r 16 --quiet 2>/dev/null \
+                  | tee >(lame --quiet -r --preset phone -s 16 - "${OUTFILE}recording-$(date -d @"$AUDIOTIME" +%y%m%d-%H%M%S).mp3" >/dev/null 2>&1) \
                   | sox -V -t raw -b 16 -r 48000 -c 1 -e signed-integer - -n sinc 200-10000 stats rate 16000 spectrogram -o "${OUTFILE}spectro-$(date -d @"$AUDIOTIME" +%y%m%d-%H%M%S).png"  -Z -10 -z 60 -t "Audio Spectrogram for $(date -d @"$AUDIOTIME")" -c "PlaneFence (C) 2020-2024 by kx1t" -p 1 2>&1 \
                   | grep 'RMS lev dB')"
     else
-        RMSREC="$(arecord -D hw:"$CARD,$DEVICE" -d "$CAPTURETIME" --fatal-errors --buffer-size=192000 -f dat -t raw -c 1 --quiet 2>/dev/null \
+        RMSREC="$(arecord -D hw:"$CARD,$DEVICE" -d "$CAPTURETIME" --fatal-errors --buffer-size=192000 -f dat -t raw -c 1 -r 16 --quiet 2>/dev/null \
                   | sox -V -t raw -b 16 -r 48000 -c 1 -e signed-integer - -n sinc 200-10000 stats rate 16000 spectrogram -o "${OUTFILE}spectro-$(date -d @"$AUDIOTIME" +%y%m%d-%H%M%S).png"  -Z -10 -z 60 -t "Audio Spectrogram for $(date -d @"$AUDIOTIME")" -c "PlaneFence (C) 2020-2024 by kx1t" -p 1 2>&1 \
                   | grep 'RMS lev dB')"
     fi


### PR DESCRIPTION
change samplerate from 44kHz to 16kHz for `arecord` and `lame` to fix audio issue. But now the spectrogram is 1/3rd of 5s, and changing the `sox` samplerate to 16kHz throws an error. The lowest sox samplerate that works is 22kHz but that produces 3.6 second spectrograms. Still needs work.